### PR TITLE
fix timestamp transfer bug,timestamp got from api in seconds not microseconds

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -28,7 +28,10 @@
             for (let item of data["data"]) {
                 let row = document.createElement("li");
                 let link = document.createElement("a");
-                link.href = item["target"]["url"];
+                // link.href = item["target"]["url"];
+                // url can reach question: https://www.zhihu.com/question/581294229
+                // url:                    https://api.zhihu.com/questions/581294229
+                link.href =  "https://www.zhihu.com/question/"+item["target"]["id"];
                 link.innerText = item["target"]["title"];
                 row.append(link);
                 let d = new Date(item["target"]["created"]);

--- a/static/index.html
+++ b/static/index.html
@@ -32,7 +32,8 @@
                 link.innerText = item["target"]["title"];
                 row.append(link);
                 let d = new Date(item["target"]["created"]);
-                row.innerHTML += " " + toDate.format(d);
+                // timestamp in seconds 
+                row.innerHTML += " " + toDate.format(d*1000);
                 listEls.push(row);
             }
             let el = document.getElementById("contents");


### PR DESCRIPTION
api 返回的时间戳是秒级的

`
// https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat.html 


let options = {
            weekday: "short",
            year: "numeric",
            month: "short",
            day: "numeric",
            hour: "numeric",
            dayPeriod: "short"
        };

const toDate = new Intl.DateTimeFormat("default", options);
console.log(toDate.format(1676732315*1000))

var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
// Results below assume UTC timezone - your results may vary

console.log(new Intl.DateTimeFormat('en-US').format(date));
// expected output: "12/20/2012"

console.log(new Intl.DateTimeFormat('en-GB').format(date));
// expected output: "20/12/2012"

// Include a fallback language, in this case Indonesian
console.log(new Intl.DateTimeFormat(['ban', 'id']).format(date));
// expected output: "20/12/2012"
`